### PR TITLE
BTA-1011 Update API documentation for account validation

### DIFF
--- a/additional-features.md
+++ b/additional-features.md
@@ -11,9 +11,11 @@ To do this initiate a call to the following endpoint:
 POST /v1/account_validations
 
 {
-  "account_id": "12345678", # account number to query
+  "bank_account": "12345678", # account number to query
   "bank_code": "000", # bank code to query - same codes are used as for creating the transactions
-  "country": "NG" # Only "NG" is supported for now
+  "country": "NG"   # Only "NG" is supported for now
+  "currency": "NGN" # Only "NGN" is supported for now
+  "method": "bank"  # Only "bank" is supported for now
 }
 ```
 


### PR DESCRIPTION
Updates the API documentation to reflect that in the future account validation and name enquiry might be supported across multiple currencies, countries and potentially even on mobile. Also renames the `account_id` field to `bank_account` to make it more consistent with how we address bank details when creating transactions.

Note that calling the endpoint the old way, e.g. skipping `currency` and `method` and using `account_id` instead of `bank_account` is still fully supported by the system