### PR TITLE
BTA-1599 Add external_id to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Status codes](#status-codes)
   - [Webhooks](#webhooks)
   - [Metadata](#metadata)
+  - [External ID](#external-id)
   - [Senders](#senders)
   - [Recipients](#recipients)
   - [Transactions](#transactions)
@@ -105,7 +106,6 @@ The following are examples of some possible webhook flows and events. Please not
 
 ![transaction-success](uml/webhook-success.png)
 
-
 #### Transaction canceled
 
 ![transaction-canceled](uml/webhook-canceled.png)
@@ -118,13 +118,19 @@ You can obtain an up-to-date list of available webhook events using the [Webhook
 
 ### Metadata
 
-Most models in the BitPesa API allow storing any metadata, which will be returned when querying the object, including callouts from webhooks. This facility can be used to store any data on the models, including for example local IDs to help link them to the models inside the API user's system.
+Most models in the BitPesa API allow storing any metadata, which will be returned when querying the object, including callouts from webhooks. This facility can be used to store any data on the models.
+
+### External ID
+
+An external ID can be included when Transactions are created, which are typically used for linking transactions to the models inside the API user's system. If the specified external ID already exists in our system the transaction will fail to validate.
 
 ### Senders
 
 The senders model stores information about who sends the money for the transaction. Only senders that are KYC'd are allowed to pay in money.
 
-If your site already does KYC on the senders, then  let us know as we might waive the requirement to send us sender documents to ease the usage of our API. Otherwise you will have to send us documents for each sender which we will validate.
+If your site already does KYC on the senders, then let us know as we might waive the requirement to send us sender documents to ease the usage of our API. Otherwise you will have to send us documents for each sender which we will validate.
+
+As with transactions, external IDs can also be included for senders when a transaction is created. If this ID already exists in our system, the transaction will fail to validate.
 
 You can read more on creating senders in the [Transaction flow documentation](transaction-flow.md).
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ Most models in the BitPesa API allow storing any metadata, which will be returne
 
 ### External ID
 
-An external ID can be included when Transactions are created, which are typically used for linking transactions to the models inside the API user's system. If the specified external ID already exists in our system the transaction will fail to validate.
+An external ID can be included when Transactions are created, which are typically used for linking transactions to the models inside the API user's system. If the specified external ID already exists in our system the transaction will fail to validate, and the corresponding duplicate transaction will be returned along with an error.
+
+For more information on External IDs, see the [Transaction flow documentation](transaction-flow.md#external-id)
 
 ### Senders
 

--- a/additional-features.md
+++ b/additional-features.md
@@ -157,7 +157,8 @@ The generic structure of a transaction that collects the equivalent of 100 USD f
       }
     }
   ],
-  "metadata": {}
+  "metadata": {},
+  "external_id": "806ec63a-a5a7-43cc-9d75-1ee74fbcc026"
 }
 ```
 

--- a/authentication.md
+++ b/authentication.md
@@ -47,6 +47,7 @@ For the following example, we will assume you are using the following details to
       }
     ],
     "ip": "127.0.0.1",
+    "external_id": "76f69f5e-912f-43e5-bf3a-9081dbc476f4",
     "metadata": { "meta": "data" }
   }
 }


### PR DESCRIPTION
Update the API documentation with reference to the new external_id field
attached to Senders and Transactions.

• Replace references to sendRef with external_id, pushing users toward
using the new functionality.
• Update examples on transaction create and transaction/sender searches
to show how to utilise this feature fully.
• Add external_id to Sender details example, with a note that this is an
optional field.
• Update surrounding documentation to accomodate external_id, where
appropriate.

Resolves: https://btcafrica.atlassian.net/browse/BTA-1599